### PR TITLE
Add missing 'NFData' instances

### DIFF
--- a/Data/EnumMap.hs
+++ b/Data/EnumMap.hs
@@ -154,6 +154,7 @@ import Data.EnumSet ( EnumSet )
 import qualified Data.EnumSet as EnumSet
 
 import Control.Arrow ( first, second, (***) )
+import Control.DeepSeq ( NFData )
 import Data.Foldable ( Foldable )
 import Data.Monoid ( Monoid )
 import Data.Traversable ( Traversable )
@@ -163,7 +164,7 @@ import Text.Read
 
 -- | Wrapper for 'IntMap' with 'Enum' keys.
 newtype EnumMap k a = EnumMap { unWrap :: IntMap a }
-  deriving (Eq, Foldable, Functor, Ord, Monoid, Traversable, Typeable)
+  deriving (Eq, Foldable, Functor, Ord, Monoid, Traversable, Typeable, NFData)
 
 instance (Enum k, Show k, Show a) => Show (EnumMap k a) where
   showsPrec p em = showParen (p > 10) $

--- a/Data/EnumSet.hs
+++ b/Data/EnumSet.hs
@@ -86,6 +86,7 @@ import qualified Prelude as P
 import Data.IntSet ( IntSet )
 import qualified Data.IntSet as I
 
+import Control.DeepSeq ( NFData )
 import Data.Monoid ( Monoid )
 import Data.Typeable ( Typeable )
 
@@ -93,7 +94,7 @@ import Text.Read
 
 -- | Wrapper for 'IntSet' with 'Enum' elements.
 newtype EnumSet e = EnumSet { unWrap :: IntSet }
-  deriving (Eq, Monoid, Ord, Typeable)
+  deriving (Eq, Monoid, Ord, Typeable, NFData)
 
 instance (Enum e, Show e) => Show (EnumSet e) where
   showsPrec p es = showParen (p > 10) $

--- a/enummapset.cabal
+++ b/enummapset.cabal
@@ -28,6 +28,7 @@ Library
 
   build-depends:
     base < 5,
-    containers >= 0.5 && < 0.6
+    containers >= 0.5 && < 0.6,
+    deepseq >= 1.2 && < 1.4
 
   ghc-options: -Wall


### PR DESCRIPTION
Starting with `containers-0.5`, the container types come equipped
with `NFData` instances, and so should `enummapset`...
