### PR TITLE
EnumMap: Use DeriveTraversable instead of GND

### DIFF
--- a/Data/EnumMap/Base.hs
+++ b/Data/EnumMap/Base.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveTraversable          #-}
 
 -- |
 -- Module      :  $Header$


### PR DESCRIPTION
GeneralizedNewtypeDeriving can no longer derive Traversable instances
with the new Roles mechanism as documented in the Wiki[1].
DeriveTraversable still works and the change should be backwards
compatible as it should produce equivalent code.

[1] http://ghc.haskell.org/trac/ghc/wiki/Roles#RolesandTraversable